### PR TITLE
fix(deps): trivy release and tags differ

### DIFF
--- a/.github/workflows/speculative-plan.yaml
+++ b/.github/workflows/speculative-plan.yaml
@@ -93,7 +93,7 @@ jobs:
           show-progress: false
 
       - name: Run with SARIF Output
-        uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55 # v0.19.0
+        uses: aquasecurity/trivy-action@d710430a6722f083d3b36b8339ff66b32f22ee55 # 0.19.0
         with:
           scan-type: "fs"
           format: "sarif"


### PR DESCRIPTION
Specifically, the `v0.19.0` release is tagged `0.19.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version reference for the security scanning tool to enhance security checks within the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->